### PR TITLE
Update to Sigil H

### DIFF
--- a/snippets/elixir.code-snippets
+++ b/snippets/elixir.code-snippets
@@ -47,8 +47,8 @@
       "defmodule ${1:App}Web.${2:Page}Live do",
       "\tuse ${1:App}Web, :live_view",
       "\n\tdef render(assigns) do",
-      "\t\t~L\"\"\"",
-      "\t\t\"\"\"",
+      "\t\t~H\"\"\"",
+      "\n\t\t\"\"\"",
       "\tend",
       "\n\tdef mount(_params, _session, socket) do",
       "\t\t$0{:ok, socket}",
@@ -62,8 +62,8 @@
       "defmodule ${1:App}Web.${2:Page}Component do",
       "\tuse ${1:App}Web, :live_component",
       "\n\tdef render(assigns) do",
-      "\t\t~L\"\"\"",
-      "\t\t\"\"\"",
+      "\t\t~H\"\"\"",
+      "\n\t\t\"\"\"",
       "\tend",
       "\n\tdef mount(socket) do",
       "\t\t$0{:ok, socket}",
@@ -78,6 +78,10 @@
   "Sigil L": {
     "prefix": "sl",
     "body": ["~L\"\"\"", "\t<div>$0</div>", "\"\"\""]
+  },
+  "Sigil H": {
+    "prefix": "sh",
+    "body": ["~H\"\"\"", "\t<div>$0</div>", "\"\"\""]
   },
 
   // LiveView Snippets
@@ -125,7 +129,7 @@
     "body": [
       "@impl true",
       "def render(assigns) do",
-      "\t~L\"\"\"",
+      "\t~H\"\"\"",
       "\t\t${1:Text}",
       "\t\"\"\"",
       "end$0"


### PR DESCRIPTION
Hello!
Phoenix now has a sigil H for heex, as it is now HTML aware.

This pull request changes the snippets from using ~L to ~H and adds a new line between the `"""`s as the formatter will add the line once the file is saved/formatted.