### PR TITLE
Add sigil p

### DIFF
--- a/snippets/eex.code-snippets
+++ b/snippets/eex.code-snippets
@@ -170,5 +170,10 @@
       "<% end %>$0"
     ],
     "description": "<%= live_redirect %> block"
+  },
+
+  "Sigil P": {
+    "prefix": "sp",
+    "body": ["~p\"$0\""]
   }
 }

--- a/snippets/elixir.code-snippets
+++ b/snippets/elixir.code-snippets
@@ -79,6 +79,10 @@
     "prefix": "sl",
     "body": ["~L\"\"\"", "\t<div>$0</div>", "\"\"\""]
   },
+  "Sigil P": {
+    "prefix": "sp",
+    "body": ["~p\"$0\""]
+  },
 
   // LiveView Snippets
   "LiveView assign": {


### PR DESCRIPTION
Sigil p is now used for compile-time checked paths instead of the route helpers.